### PR TITLE
Update rail-bencode.el

### DIFF
--- a/rail-bencode.el
+++ b/rail-bencode.el
@@ -372,7 +372,7 @@ nested inputs."
 					   :dict-type dict-type
 					   :coding-system coding-system)
 		      responses)))
-      (delete-dups responses))))
+      responses)))
 
 (provide 'rail-bencode)
 


### PR DESCRIPTION
i do not know why delete-dups was there, but it will make fail simple decoding like

(rail-bencode-decode "d1:a1:x1:b1:xe")

it will deduplicate the values of the dict (plist)