### PR TITLE
Update rail.el

### DIFF
--- a/rail.el
+++ b/rail.el
@@ -622,8 +622,9 @@ by locatin rail-nrepl-server-project-file"
 (defun rail-interrupt ()
   "Send interrupt to all pending requests."
   (interactive)
-  (cl-loop for id being the hash-key of rail-requests
-           do (rail-send-interrupt id (rail-make-response-handler))))
+  (let ((rail-requests-snapshot (copy-hash-table rail-requests)))
+    (cl-loop for id being the hash-key of rail-requests-snapshot
+             do (rail-send-interrupt id (rail-make-response-handler)))))
 
 ;; keys for interacting with Rail REPL buffer
 (defvar rail-interaction-mode-map


### PR DESCRIPTION
currently (emacs 28.2 on windows) if i send an interrupt, it adds a request in rail-requests and the cl-loop loops for infinity.

so i simply added a copy so we can iterate on something that we do not mutate at the same time