### PR TITLE
rail: ensure .nrepl-port is read as a number

### DIFF
--- a/rail.el
+++ b/rail.el
@@ -345,7 +345,7 @@ rail-repl-buffer."
     (when dir
       (with-temp-buffer
         (insert-file-contents (concat dir ".nrepl-port"))
-        (concat "localhost:" (buffer-string))))))
+        (format "localhost:%d" (string-to-number (buffer-string)))))))
 
 (defun rail-extract-host (buff-name)
   "Take host from rail buffers."


### PR DESCRIPTION
When .nrepl-port has a newline ending, current implementation doesn't work. This patch ensures this case is covered.